### PR TITLE
Implement necessary exported types for compatibility with Teleport

### DIFF
--- a/azuread/configuration.go
+++ b/azuread/configuration.go
@@ -71,6 +71,21 @@ func parse(dsn string) (*azureFedAuthConfig, error) {
 	return config, nil
 }
 
+// newConfig returns a config based on an msdsn.Config and a map of parameters.
+func newConfig(dsnConfig msdsn.Config, params map[string]string) (*azureFedAuthConfig, error) {
+	config := &azureFedAuthConfig{
+		fedAuthLibrary: mssql.FedAuthLibraryReserved,
+		mssqlConfig:    dsnConfig,
+	}
+
+	err := config.validateParameters(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
 func (p *azureFedAuthConfig) validateParameters(params map[string]string) error {
 
 	fedAuthWorkflow, _ := params["fedauth"]

--- a/azuread/driver.go
+++ b/azuread/driver.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-
 	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
 )
 
 // DriverName is the name used to register the driver
@@ -40,6 +40,16 @@ func NewConnector(dsn string) (*mssql.Connector, error) {
 	if err != nil {
 		return nil, err
 	}
+	return newConnectorConfig(config)
+}
+
+// NewConnectorFromConfig returns a new connector with the provided configuration and additional parameters
+func NewConnectorFromConfig(dsnConfig msdsn.Config, params map[string]string) (*mssql.Connector, error) {
+	config, err := newConfig(dsnConfig, params)
+	if err != nil {
+		return nil, err
+	}
+
 	return newConnectorConfig(config)
 }
 

--- a/buf.go
+++ b/buf.go
@@ -28,6 +28,8 @@ var bufpool = sync.Pool{
 	},
 }
 
+type TDSBuffer = tdsBuffer
+
 // tdsBuffer reads and writes TDS packets of data to the transport.
 // The write and read buffers are separate to make sending attn signals
 // possible without locks. Currently attn signals are only sent during
@@ -57,6 +59,14 @@ type tdsBuffer struct {
 	// before the first use. It is executed after the first packet is
 	// written and then removed.
 	afterFirst func()
+}
+
+// NewTdsBuffer returns an exported version of *tdsBuffer
+func NewTdsBuffer(buff []byte, size int) *TDSBuffer {
+	return &tdsBuffer{
+		rbuf:  buff,
+		rsize: size,
+	}
 }
 
 func newTdsBuffer(bufsize uint16, transport io.ReadWriteCloser) *tdsBuffer {

--- a/tds.go
+++ b/tds.go
@@ -143,6 +143,7 @@ type tdsSession struct {
 	logger       ContextLogger
 	routedServer string
 	routedPort   uint16
+	loginFlags   []Token
 }
 
 const (
@@ -168,9 +169,23 @@ func (p keySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // http://msdn.microsoft.com/en-us/library/dd357559.aspx
 func writePrelogin(packetType packetType, w *tdsBuffer, fields map[uint8][]byte) error {
+	w.BeginPacket(packetType, false)
+	if err := WritePreLoginFields(w, fields); err != nil {
+		return err
+	}
+	return w.FinishPacket()
+}
+
+// Writer is an interface that combines Writer and ByteWriter.
+type Writer interface {
+	io.Writer
+	io.ByteWriter
+}
+
+// WritePreLoginFields writes provided Pre-Login packet fields into the writer.
+func WritePreLoginFields(w Writer, fields map[uint8][]byte) error {
 	var err error
 
-	w.BeginPacket(packetType, false)
 	offset := uint16(5*len(fields) + 1)
 	keys := make(keySlice, 0, len(fields))
 	for k := range fields {
@@ -210,7 +225,7 @@ func writePrelogin(packetType packetType, w *tdsBuffer, fields map[uint8][]byte)
 			return errors.New("Write method didn't write the whole value")
 		}
 	}
-	return w.FinishPacket()
+	return nil
 }
 
 func readPrelogin(r *tdsBuffer) (map[uint8][]byte, error) {
@@ -1193,6 +1208,15 @@ initiate_connection:
 
 			if tok == nil {
 				break
+			}
+
+			// Save options returned by the server so callers implementing
+			// proxies can pass them back to the original client.
+			switch tok.(type) {
+			case envChangeStruct, loginAckStruct, doneStruct:
+				if token, ok := tok.(Token); ok {
+					sess.loginFlags = append(sess.loginFlags, token)
+				}
 			}
 
 			switch token := tok.(type) {

--- a/types.go
+++ b/types.go
@@ -85,6 +85,8 @@ const (
 	fDefault = 0x200
 )
 
+type TypeInfo = typeInfo
+
 // TYPE_INFO rule
 // http://msdn.microsoft.com/en-us/library/dd358284.aspx
 type typeInfo struct {
@@ -117,6 +119,11 @@ type xmlInfo struct {
 	DBName              string
 	OwningSchema        string
 	XmlSchemaCollection string
+}
+
+// ReadTypeInfo returns an exported version of typeInfo
+func ReadTypeInfo(r *TDSBuffer) TypeInfo {
+	return readTypeInfo(r)
 }
 
 func readTypeInfo(r *tdsBuffer) (res typeInfo) {

--- a/ucs22str.go
+++ b/ucs22str.go
@@ -149,3 +149,8 @@ func ucs22str(s []byte) (string, error) {
 	// After this point both s and uint16slice can be garbage collected.
 	return string(utf16.Decode(uint16slice)), nil
 }
+
+// ParseUCS2String returns string from its UCS-2 encoded representation.
+func ParseUCS2String(s []byte) (string, error) {
+	return ucs22str(s)
+}


### PR DESCRIPTION
This is necessary for us to move over to Microsoft's fork of go-msssqldb, since we would like to take their updates/security fixes, and also apply our own.