### PR TITLE
Use fixed buffer size when reading variable length messages

### DIFF
--- a/types.go
+++ b/types.go
@@ -673,7 +673,9 @@ func readPLPType(ti *typeInfo, r *tdsBuffer) interface{} {
 		// size unknown
 		buf = bytes.NewBuffer(make([]byte, 0, 1000))
 	default:
-		buf = bytes.NewBuffer(make([]byte, 0, size))
+		// Uses a fixed buffer size to avoid overflow.
+		// Same size as used on `io.Copy` internal buffer: https://github.com/golang/go/blob/release-branch.go1.20/src/io/io.go#L416
+		buf = bytes.NewBuffer(make([]byte, 0, 32*1024))
 	}
 	for {
 		chunksize := r.uint32()

--- a/types.go
+++ b/types.go
@@ -673,8 +673,10 @@ func readPLPType(ti *typeInfo, r *tdsBuffer) interface{} {
 		// size unknown
 		buf = bytes.NewBuffer(make([]byte, 0, 1000))
 	default:
-		// Uses a fixed buffer size to avoid overflow.
-		// Same size as used on `io.Copy` internal buffer: https://github.com/golang/go/blob/release-branch.go1.20/src/io/io.go#L416
+		// PLP types can set their size to max unit64 (2^64) bytes causing a
+		// large allocation that can takes some time to complete or panic
+		// due to lack of memory. To avoid this we're using a fixed size buffer
+		// with same size as used on `io.Copy` internal buffer: https://github.com/golang/go/blob/release-branch.go1.20/src/io/io.go#L416
 		buf = bytes.NewBuffer(make([]byte, 0, 32*1024))
 	}
 	for {


### PR DESCRIPTION
Instead of using the size defined by the RPC message for the read buffer, use a fixed size to avoid overflows.

Tests are going to be included on the Teleport side.