### PR TITLE
Apply Teleport-specific patches on top of v1.8.1

### DIFF
--- a/azuread/configuration.go
+++ b/azuread/configuration.go
@@ -62,12 +62,18 @@ func parse(dsn string) (*azureFedAuthConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return newConfig(mssqlConfig)
+}
+
+// newConfig returns a config based on an msdsn.Config and a map of parameters.
+func newConfig(dsnConfig msdsn.Config) (*azureFedAuthConfig, error) {
 	config := &azureFedAuthConfig{
 		fedAuthLibrary: mssql.FedAuthLibraryReserved,
-		mssqlConfig:    mssqlConfig,
+		mssqlConfig:    dsnConfig,
 	}
 
-	err = config.validateParameters(mssqlConfig.Parameters)
+	err := config.validateParameters(dsnConfig.Parameters)
 	if err != nil {
 		return nil, err
 	}

--- a/azuread/driver.go
+++ b/azuread/driver.go
@@ -9,6 +9,7 @@ import (
 	"database/sql/driver"
 
 	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
 )
 
 // DriverName is the name used to register the driver
@@ -35,11 +36,19 @@ func (d *Driver) Open(dsn string) (driver.Conn, error) {
 // NewConnector creates a new connector from a DSN.
 // The returned connector may be used with sql.OpenDB.
 func NewConnector(dsn string) (*mssql.Connector, error) {
-
 	config, err := parse(dsn)
 	if err != nil {
 		return nil, err
 	}
+	return newConnectorConfig(config)
+}
+
+func NewConnectorFromConfig(dsnConfig msdsn.Config) (*mssql.Connector, error) {
+	config, err := newConfig(dsnConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return newConnectorConfig(config)
 }
 

--- a/buf.go
+++ b/buf.go
@@ -28,6 +28,8 @@ var bufpool = sync.Pool{
 	},
 }
 
+type TDSBuffer = tdsBuffer
+
 // tdsBuffer reads and writes TDS packets of data to the transport.
 // The write and read buffers are separate to make sending attn signals
 // possible without locks. Currently attn signals are only sent during
@@ -57,6 +59,13 @@ type tdsBuffer struct {
 	// before the first use. It is executed after the first packet is
 	// written and then removed.
 	afterFirst func()
+}
+
+func NewTdsBuffer(buff []byte, size int) *tdsBuffer {
+	return &tdsBuffer{
+		rbuf:  buff,
+		rsize: size,
+	}
 }
 
 func newTdsBuffer(bufsize uint16, transport io.ReadWriteCloser) *tdsBuffer {

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -134,11 +134,13 @@ type Config struct {
 	Protocols []string
 	// ProtocolParameters are written by non-tcp ProtocolParser implementations
 	ProtocolParameters map[string]interface{}
+	// LoginOptions allows to pass option flags to the server during login.
+	LoginOptions LoginOptions
 	// BrowserMsg is the message identifier to fetch instance data from SQL browser
 	BrowserMessage BrowserMsg
 	// ChangePassword is used to set the login's password during login. Ignored for non-SQL authentication.
 	ChangePassword string
-	//ColumnEncryption is true if the application needs to decrypt or encrypt Always Encrypted values
+	// ColumnEncryption is true if the application needs to decrypt or encrypt Always Encrypted values
 	ColumnEncryption bool
 	// Attempt to connect to all IPs in parallel when MultiSubnetFailover is true
 	MultiSubnetFailover bool
@@ -149,6 +151,14 @@ type Config struct {
 	NoTraceID bool
 	// Parameters related to type encoding
 	Encoding EncodeParameters
+}
+
+// LoginOptions combines option flags and other login options.
+type LoginOptions struct {
+	OptionFlags1 uint8
+	OptionFlags2 uint8
+	TypeFlags    uint8
+	OptionFlags3 uint8
 }
 
 func readDERFile(filename string) ([]byte, error) {

--- a/mssql.go
+++ b/mssql.go
@@ -17,7 +17,9 @@ import (
 	"unicode"
 
 	"github.com/golang-sql/sqlexp"
+
 	"github.com/microsoft/go-mssqldb/aecmk"
+	"github.com/microsoft/go-mssqldb/integratedauth"
 	"github.com/microsoft/go-mssqldb/internal/querytext"
 	"github.com/microsoft/go-mssqldb/msdsn"
 )
@@ -139,6 +141,13 @@ func NewConnectorWithAccessTokenProvider(dsn string, tokenProvider func(ctx cont
 	)
 }
 
+// NewConnectorConfigCustomAuth is like NewConnectorConfig, but also injects custom auth implementation.
+func NewConnectorConfigCustomAuth(config msdsn.Config, auth integratedauth.IntegratedAuthenticator) *Connector {
+	conn := newConnector(config, driverInstanceNoProcess)
+	conn.auth = auth
+	return conn
+}
+
 // NewConnectorConfig creates a new Connector for a DSN Config struct.
 // The returned connector may be used with sql.OpenDB.
 func NewConnectorConfig(config msdsn.Config) *Connector {
@@ -171,6 +180,9 @@ type Connector struct {
 
 	// callback that can provide a security token during ADAL login
 	adalTokenProvider func(ctx context.Context, serverSPN, stsURL string) (string, error)
+
+	// auth allows to provide custom authenticator.
+	auth integratedauth.IntegratedAuthenticator
 
 	// SessionInitSQL is executed after marking a given session to be reset.
 	// When not present, the next query will still reset the session to the
@@ -248,6 +260,16 @@ type outputs struct {
 // IsValid satisfies the driver.Validator interface.
 func (c *Conn) IsValid() bool {
 	return c.connectionGood
+}
+
+// GetUnderlyingConn returns underlying raw server connection.
+func (c *Conn) GetUnderlyingConn() io.ReadWriteCloser {
+	return c.sess.buf.transport
+}
+
+// GetLoginFlags returns tokens returned by server during login handshake.
+func (c *Conn) GetLoginFlags() []Token {
+	return c.sess.loginFlags
 }
 
 // checkBadConn marks the connection as bad based on the characteristics
@@ -754,8 +776,8 @@ loop:
 				// This improves results in queries like that:
 				// set nocount on; select 1
 				// see TestIgnoreEmptyResults test
-				//case doneStruct:
-				//break loop
+				// case doneStruct:
+				// break loop
 				case []columnStruct:
 					cols = token
 					break loop

--- a/tds.go
+++ b/tds.go
@@ -170,6 +170,7 @@ type tdsSession struct {
 	logger          ContextLogger
 	routedServer    string
 	routedPort      uint16
+	loginFlags      []Token
 	alwaysEncrypted bool
 	aeSettings      *alwaysEncryptedSettings
 	connid          UniqueIdentifier
@@ -227,11 +228,23 @@ type preloginOption struct {
 
 var preloginOptionSize = binary.Size(preloginOption{})
 
+// Writer is an interface that combines Writer and ByteWriter.
+type Writer interface {
+	io.Writer
+	io.ByteWriter
+}
+
 // http://msdn.microsoft.com/en-us/library/dd357559.aspx
 func writePrelogin(packetType packetType, w *tdsBuffer, fields map[uint8][]byte) error {
-	var err error
-
 	w.BeginPacket(packetType, false)
+	if err := WritePreLoginFields(w, fields); err != nil {
+		return err
+	}
+	return w.FinishPacket()
+}
+
+func WritePreLoginFields(w Writer, fields map[uint8][]byte) error {
+	var err error
 	offset := uint16(5*len(fields) + 1)
 	keys := make(keySlice, 0, len(fields))
 	for k := range fields {
@@ -271,7 +284,7 @@ func writePrelogin(packetType packetType, w *tdsBuffer, fields map[uint8][]byte)
 			return errors.New("Write method didn't write the whole value")
 		}
 	}
-	return w.FinishPacket()
+	return nil
 }
 
 func readPrelogin(r *tdsBuffer) (map[uint8][]byte, error) {
@@ -588,6 +601,11 @@ const (
 	mask32 uint32 = 0xFF80FF80
 	mask16 uint16 = 0xFF80
 )
+
+// ParseUCS2String returns string from its UCS-2 encoded representation.
+func ParseUCS2String(s []byte) (string, error) {
+	return ucs22str(s)
+}
 
 func manglePassword(password string) []byte {
 	var ucs2password []byte = str2ucs2(password)
@@ -1058,6 +1076,11 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger Cont
 		ChangePassword: p.ChangePassword,
 		ClientPID:      uint32(os.Getpid()),
 	}
+	l.OptionFlags1 |= p.LoginOptions.OptionFlags1
+	l.OptionFlags2 |= p.LoginOptions.OptionFlags2
+	// l.OptionFlags3 |= p.LoginOptions.OptionFlags3
+	l.TypeFlags |= p.LoginOptions.TypeFlags
+
 	getClientId(&l.ClientID)
 	if p.ColumnEncryption {
 		_ = l.FeatureExt.Add(&featureExtColumnEncryption{})
@@ -1118,7 +1141,7 @@ func getTLSConn(conn *timeoutConn, p msdsn.Config, alpnSeq string) (tlsConn *tls
 			return nil, err
 		}
 	}
-	//Set ALPN Sequence
+	// Set ALPN Sequence
 	config.NextProtos = []string{alpnSeq}
 	tlsConn = tls.Client(conn.c, config)
 	err = tlsConn.Handshake()
@@ -1208,7 +1231,7 @@ initiate_connection:
 		return nil, err
 	}
 
-	//We need not perform TLS handshake if the communication channel is already encrypted (encrypt=strict)
+	// We need not perform TLS handshake if the communication channel is already encrypted (encrypt=strict)
 	if !isTransportEncrypted {
 		if encrypt != encryptNotSup {
 			var config *tls.Config
@@ -1251,17 +1274,18 @@ initiate_connection:
 
 	}
 
-	auth, err := integratedauth.GetIntegratedAuthenticator(p)
-	if err != nil {
-		if uint64(p.LogFlags)&logDebug != 0 {
-			logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("Error while creating integrated authenticator: %v", err))
+	auth := c.auth
+	if auth == nil {
+		auth, err = integratedauth.GetIntegratedAuthenticator(p)
+		if err != nil {
+			if uint64(p.LogFlags)&logDebug != 0 {
+				logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("Error while creating integrated authenticator: %v", err))
+			}
+			return nil, err
 		}
-
-		return nil, err
-	}
-
-	if auth != nil {
-		defer auth.Free()
+		if auth != nil {
+			defer auth.Free()
+		}
 	}
 
 	login, err := prepareLogin(ctx, c, p, logger, auth, fedAuth, uint32(outbuf.PackageSize()))
@@ -1292,6 +1316,15 @@ initiate_connection:
 				break
 			}
 
+			// Save options returned by the server so callers implementing
+			// proxies can pass them back to the original client.
+			switch tok.(type) {
+			case envChangeStruct, loginAckStruct, doneStruct:
+				if token, ok := tok.(Token); ok {
+					sess.loginFlags = append(sess.loginFlags, token)
+				}
+			}
+
 			switch token := tok.(type) {
 			case sspiMsg:
 				sspi_msg, err := auth.NextBytes(token)
@@ -1312,8 +1345,8 @@ initiate_connection:
 				}
 			// TODO: for Live ID authentication it may be necessary to
 			// compare fedAuth.Nonce == token.Nonce and keep track of signature
-			//case fedAuthAckStruct:
-			//fedAuth.Signature = token.Signature
+			// case fedAuthAckStruct:
+			// fedAuth.Signature = token.Signature
 			case fedAuthInfoStruct:
 				// For ADAL workflows this contains the STS URL and server SPN.
 				// If received outside of an ADAL workflow, ignore.

--- a/token.go
+++ b/token.go
@@ -556,13 +556,6 @@ func parseFedAuthInfo(r *tdsBuffer) fedAuthInfoStruct {
 	}
 }
 
-// LoginAckToken returns a LoginAck token.
-func LoginAckToken() Token {
-	return loginAckStruct{
-		TDSVersion: verTDS74,
-	}
-}
-
 type loginAckStruct struct {
 	Interface  uint8
 	TDSVersion uint32

--- a/token.go
+++ b/token.go
@@ -10,12 +10,13 @@ import (
 	"strconv"
 
 	"github.com/golang-sql/sqlexp"
+	"golang.org/x/text/encoding/unicode"
+
 	"github.com/microsoft/go-mssqldb/aecmk"
 	"github.com/microsoft/go-mssqldb/internal/github.com/swisscom/mssql-always-encrypted/pkg/algorithms"
 	"github.com/microsoft/go-mssqldb/internal/github.com/swisscom/mssql-always-encrypted/pkg/encryption"
 	"github.com/microsoft/go-mssqldb/internal/github.com/swisscom/mssql-always-encrypted/pkg/keys"
 	"github.com/microsoft/go-mssqldb/msdsn"
-	"golang.org/x/text/encoding/unicode"
 )
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type token
@@ -112,8 +113,18 @@ const (
 // interface for all tokens
 type tokenStruct interface{}
 
+// Token represents a token that can be marshaled to wire representation.
+type Token interface {
+	Marshal() ([]byte, error)
+}
+
 type orderStruct struct {
 	ColIds []uint16
+}
+
+// DoneToken returns a Done token.
+func DoneToken() Token {
+	return doneStruct{}
 }
 
 type doneStruct struct {
@@ -121,6 +132,23 @@ type doneStruct struct {
 	CurCmd   uint16
 	RowCount uint64
 	errors   []Error
+}
+
+// Marshal returns the token's wire protocol representation.
+func (d doneStruct) Marshal() ([]byte, error) {
+	buf := bytes.NewBuffer([]byte{
+		byte(tokenDone),
+	})
+	if err := binary.Write(buf, binary.LittleEndian, d.Status); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, d.CurCmd); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, d.RowCount); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func (d doneStruct) isError() bool {
@@ -141,17 +169,35 @@ func (d doneStruct) getError() Error {
 
 type doneInProcStruct doneStruct
 
+type envChangeStruct struct {
+	bytes []byte
+}
+
+// Marshal returns the token's wire protocol representation.
+func (e envChangeStruct) Marshal() ([]byte, error) {
+	return e.bytes, nil
+}
+
 // ENVCHANGE stream
 // http://msdn.microsoft.com/en-us/library/dd303449.aspx
-func processEnvChg(ctx context.Context, sess *tdsSession) {
+func processEnvChg(ctx context.Context, sess *tdsSession) envChangeStruct {
+	buf := bytes.NewBuffer([]byte{
+		byte(tokenEnvChange),
+	})
 	size := sess.buf.uint16()
-	r := &io.LimitedReader{R: sess.buf, N: int64(size)}
+	if err := binary.Write(buf, binary.LittleEndian, size); err != nil {
+		badStreamPanic(err)
+	}
+	// Duplicate the token stream in the buffer.
+	r := io.TeeReader(&io.LimitedReader{R: sess.buf, N: int64(size)}, buf)
 	for {
 		var err error
 		var envtype uint8
 		err = binary.Read(r, binary.LittleEndian, &envtype)
 		if err == io.EOF {
-			return
+			return envChangeStruct{
+				bytes: buf.Bytes(),
+			}
 		}
 		if err != nil {
 			badStreamPanic(err)
@@ -392,7 +438,9 @@ func processEnvChg(ctx context.Context, sess *tdsSession) {
 		default:
 			// ignore rest of records because we don't know how to skip those
 			sess.LogF(ctx, msdsn.LogDebug, "WARN: Unknown ENVCHANGE record detected with type id = %d", envtype)
-			return
+			return envChangeStruct{
+				bytes: buf.Bytes(),
+			}
 		}
 	}
 }
@@ -508,11 +556,51 @@ func parseFedAuthInfo(r *tdsBuffer) fedAuthInfoStruct {
 	}
 }
 
+// LoginAckToken returns a LoginAck token.
+func LoginAckToken() Token {
+	return loginAckStruct{
+		TDSVersion: verTDS74,
+	}
+}
+
 type loginAckStruct struct {
 	Interface  uint8
 	TDSVersion uint32
 	ProgName   string
 	ProgVer    uint32
+}
+
+// Marshal returns the token's wire protocol representation.
+func (l loginAckStruct) Marshal() ([]byte, error) {
+	buf := bytes.NewBuffer([]byte{
+		byte(tokenLoginAck),
+	})
+	size := uint16(1 + // interface: uint8
+		4 + // version: uint32
+		1 + // prog name len: uint8
+		len(l.ProgName)*2 + // UCS2 encoded prog name
+		4, // prog version: uint32
+	)
+	if err := binary.Write(buf, binary.LittleEndian, size); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, l.Interface); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, l.TDSVersion); err != nil {
+		return nil, err
+	}
+	progName := str2ucs2(l.ProgName)
+	if err := binary.Write(buf, binary.LittleEndian, uint8(len(progName)/2)); err != nil {
+		return nil, err
+	}
+	if _, err := buf.Write(progName); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, l.ProgVer); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func parseLoginAck(r *tdsBuffer) loginAckStruct {
@@ -1084,7 +1172,8 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 			}
 			ch <- row
 		case tokenEnvChange:
-			processEnvChg(ctx, sess)
+			envChg := processEnvChg(ctx, sess)
+			ch <- envChg
 		case tokenError:
 			err := parseError72(sess.buf)
 			sess.LogF(ctx, msdsn.LogDebug, "got ERROR %d %s", err.Number, err.Message)

--- a/types.go
+++ b/types.go
@@ -123,6 +123,10 @@ type xmlInfo struct {
 	XmlSchemaCollection string
 }
 
+func ReadTypeInfo(r *TDSBuffer, typeId byte, c *cryptoMetadata, encoding msdsn.EncodeParameters) typeInfo {
+	return readTypeInfo(r, typeId, c, encoding)
+}
+
 func readTypeInfo(r *tdsBuffer, typeId byte, c *cryptoMetadata, encoding msdsn.EncodeParameters) (res typeInfo) {
 	res.TypeId = typeId
 	switch typeId {

--- a/types.go
+++ b/types.go
@@ -746,7 +746,11 @@ func readPLPType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata) interface{} {
 			// size unknown
 			buf = bytes.NewBuffer(make([]byte, 0, 1000))
 		default:
-			buf = bytes.NewBuffer(make([]byte, 0, size))
+			// PLP types can set their size to max unit64 (2^64) bytes causing a
+			// large allocation that can takes some time to complete or panic
+			// due to lack of memory. To avoid this we're using a fixed size buffer
+			// with same size as used on `io.Copy` internal buffer: https://github.com/golang/go/blob/release-branch.go1.20/src/io/io.go#L416
+			buf = bytes.NewBuffer(make([]byte, 0, 32*1024))
 		}
 		for {
 			chunksize := r.uint32()


### PR DESCRIPTION
Upstream is at https://github.com/microsoft/go-mssqldb/releases/tag/v1.8.1 (https://github.com/microsoft/go-mssqldb/commit/6b3e174847c01b9c2e180382d293ae9fb49ec8db)

This is just like https://github.com/gravitational/go-mssqldb/pull/17, but applied to a slightly different (tagged) baseline.